### PR TITLE
Add MX record support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An authoritative DNS nameserver that queries an [etcd](http://github.com/coreos/
     - `CNAME` alias records
     - Delegation via `NS` and `SOA` records
     - `SRV` and `PTR` for service discovery and reverse domain lookups
+    - `MX` records for email support
 - Multiple resource records of different types per domain (where valid)
 - Support for wildcard domains
 - Support for TTLs
@@ -162,6 +163,25 @@ curl -L http://127.0.0.1:4001/v2/keys/net/discodns/.NS/ns2 -XPUT -d value=ns2.di
 ```
 
 **Don't forget to ensure you also add `A` records for the `ns{1,2}.discodns.net` domains to ensure they can resolve to IPs.**
+
+#### MX
+
+MX records are needed so that we can receive email for our domain.
+
+```
+curl -L http://127.0.0.1:4001/v2/keys/net/discodns/.MX/primary -XPUT -d value=$'10\tmail1.discodns.net.'
+{"action":"set","node":{"key":"/net/discodns/.MX/primary","value":"...","modifiedIndex":14,"createdIndex":14}}
+```
+
+```
+curl -L http://127.0.0.1:4001/v2/keys/net/discodns/.MX/primary -XPUT -d value=$'20\tmail2.discodns.net.'
+{"action":"set","node":{"key":"/net/discodns/.MX/primary","value":"...","modifiedIndex":15,"createdIndex":15}}
+```
+
+MX records require two fields in the value: preference and hostname. MX records
+with lower preferences have a higher priority.
+
+**Don't forget to ensure you also add `A` records for the `mail{1,2}.discodns.net` domains to ensure they can resolve to IPs.**
 
 ## Storage
 

--- a/resolver.go
+++ b/resolver.go
@@ -366,6 +366,15 @@ var converters = map[uint16]func(node *etcd.Node, header dns.RR_Header) (rr dns.
 		rr = &dns.TXT{Hdr: header, Txt: []string{node.Value}}
 		return
 	},
+	dns.TypeMX: func(node *etcd.Node, header dns.RR_Header) (rr dns.RR, err error) {
+		parts := strings.SplitN(node.Value, "\t", 2)
+		preference, err := strconv.ParseUint(parts[0], 10, 16)
+		if err != nil {
+			return nil, err
+		}
+		rr = &dns.MX{Hdr: header, Preference: uint16(preference), Mx: dns.Fqdn(parts[1])}
+		return
+        },
 	dns.TypeCNAME: func(node *etcd.Node, header dns.RR_Header) (rr dns.RR, err error) {
 		rr = &dns.CNAME{Hdr: header, Target: dns.Fqdn(node.Value)}
 		return

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	client   = etcd.NewClient([]string{"http://172.17.0.2:4001"})
+	client   = etcd.NewClient([]string{"http://127.0.0.1:4001"})
 	resolver = &Resolver{etcd: client}
 )
 


### PR DESCRIPTION
Adding support for MX records in the same style of NS records. README.md updated to document how to use the records, and a quick unit test to verify it functions correctly.